### PR TITLE
Hero editorial con foto del centro + refinamientos mobile-first

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -18,3 +18,4 @@ yarn-debug.log*
 Thumbs.db
 .idea/
 .vscode/
+.claude/

--- a/frontend/src/components/Footer.astro
+++ b/frontend/src/components/Footer.astro
@@ -65,7 +65,7 @@ const year = new Date().getFullYear();
         </div>
 
         <nav
-          class="flex flex-wrap justify-center space-x-4 text-sm font-medium"
+          class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-sm font-medium"
         >
           {
             quickLinks.map((link) => (
@@ -90,7 +90,7 @@ const year = new Date().getFullYear();
                 d="M21.75 7.5v9a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25v-9m19.5 0A2.25 2.25 0 0019.5 5.25h-15A2.25 2.25 0 002.25 7.5m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0l-7.5-4.615A2.25 2.25 0 012.25 7.743V7.5"
               ></path>
             </svg>
-            <span class="relative z-10 text-xs sm:text-sm">Contacto</span>
+            <span class="relative z-10 text-sm">Contacto</span>
           </ContactoModal>
         </nav>
       </div>

--- a/frontend/src/components/Header.astro
+++ b/frontend/src/components/Header.astro
@@ -85,7 +85,9 @@ const currentPath = Astro.url.pathname;
 
     <!-- Desktop Mega Menu -->
     <ul class="hidden lg:flex items-center gap-1 h-full" role="menubar" aria-label="Menú principal">
-      {megaMenu.map((section) => (
+      {megaMenu.map((section, i) => {
+        const alignRight = i >= megaMenu.length - 2;
+        return (
         <li class="relative h-full flex items-center group" role="none">
           <!-- Trigger -->
           <a
@@ -108,7 +110,9 @@ const currentPath = Astro.url.pathname;
 
           <!-- Dropdown Panel — controlado por JS (hover + focus) -->
           <div
-            class="absolute top-full left-1/2 -translate-x-1/2 pt-2 opacity-0 invisible transition-all duration-200 ease-out"
+            class={`absolute top-full pt-2 opacity-0 invisible transition-all duration-200 ease-out ${
+              alignRight ? 'right-0' : 'left-1/2 -translate-x-1/2'
+            }`}
             role="menu"
             aria-label={`Submenú de ${section.name}`}
             data-mega-panel
@@ -133,7 +137,8 @@ const currentPath = Astro.url.pathname;
             </div>
           </div>
         </li>
-      ))}
+        );
+      })}
     </ul>
 
     <!-- Hamburger Button (mobile) -->

--- a/frontend/src/components/Hero.astro
+++ b/frontend/src/components/Hero.astro
@@ -1,41 +1,48 @@
 ---
 const heroImage = "/images/portadaJandula.jpg";
+const serif = "'Newsreader', Georgia, 'Times New Roman', serif";
 ---
 
 <section
-        class="relative w-full h-[600px] flex items-center justify-center overflow-hidden"
-        aria-label="Bienvenida al IES Jándula"
+  class="relative w-full min-h-[68svh] md:min-h-[72svh] max-h-[640px] flex items-end overflow-hidden"
+  aria-label="Bienvenida al IES Jándula"
 >
-    <img
-        src={heroImage}
-        alt="Fachada y estudiantes del IES Jándula"
-        class="absolute inset-0 w-full h-full object-cover"
-        loading="eager"
-    />
-    <div class="relative z-10 container mx-auto px-4 h-full flex items-center justify-center">
+  <img
+    src={heroImage}
+    alt="Fachada del IES Jándula"
+    class="absolute inset-0 w-full h-full object-cover"
+    loading="eager"
+  />
 
-        <div class="max-w-3xl w-full flex flex-col items-center">
+  <!-- Overlay oscuro uniforme -->
+  <div class="absolute inset-0 bg-black/55" aria-hidden="true"></div>
 
-            <div class="w-full bg-gradient-to-r from-jandula-blue/60 to-jandula-green/60 saturate-150 p-8 md:p-12 rounded-3xl shadow-2xl backdrop-blur-md text-white mb-8">
+  <!-- Texto alineado abajo-izquierda: editorial y limpio -->
+  <div class="relative z-10 container mx-auto px-4 pb-20 md:pb-24">
+    <div class="max-w-2xl">
+      <span class="inline-block text-[11px] font-semibold tracking-widest uppercase text-white/50 mb-5">
+        Andújar, Jaén — Instituto de Educación Secundaria
+      </span>
 
-                <h1 class="text-4xl md:text-5xl font-bold mb-4 leading-tight">
-                    IES Jándula
-                </h1>
+      <h1
+        class="text-5xl sm:text-6xl text-white mb-5"
+        style={`font-family: ${serif}; letter-spacing: -0.03em; line-height: 1.08;`}
+      >
+        IES Jándula
+      </h1>
 
-                <p class="text-lg md:text-xl font-medium opacity-90 leading-relaxed">
-                    Formación Profesional, Bachillerato y una apuesta decidida por la internacionalización con Erasmus+. <b>Tu futuro empieza aquí.</b>
-                </p>
+      <p class="text-base md:text-lg text-white/75 mb-8 leading-relaxed max-w-lg">
+        Formación Profesional, Bachillerato e internacionalización Erasmus+.
+        Formamos personas preparadas para el mundo real.
+      </p>
 
-                <a href="/nuestro_centro"
-                       class="block w-fit mx-auto bg-blue-700/60 mt-9 text-white px-10 py-4 rounded-full font-bold text-lg hover:bg-gray-900 transition-transform transform hover:scale-105 shadow-xl border-2 border-white/20"
-            >
-                Conoce el centro
-            </a>
-
-            </div>
-
-
-
-        </div>
+      <a
+        href="/nuestro_centro"
+        class="inline-block bg-white text-[#1e3a8a] px-7 py-3 text-sm font-semibold hover:bg-[#F8F7F4] transition-colors duration-200"
+        style="border-radius: 6px;"
+      >
+        Conoce el centro
+      </a>
     </div>
+  </div>
 </section>

--- a/frontend/src/pages/orientacion.astro
+++ b/frontend/src/pages/orientacion.astro
@@ -7,7 +7,7 @@ import Layout from '@layouts/Layout.astro';
   <!-- Hero Section -->
   <div class="relative isolate overflow-hidden bg-gradient-to-br from-emerald-900 via-teal-800 to-cyan-900">
     <div class="absolute inset-0 bg-[url('/images/bg-hero.webp')] bg-cover bg-center opacity-10"></div>
-    <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8 relative z-10">
+    <div class="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:py-32 lg:px-8 relative z-10">
       <div class="mx-auto max-w-2xl text-center">
         <h1 class="text-4xl font-bold tracking-tight text-white sm:text-6xl">
           Orientación y Comunidad
@@ -15,16 +15,16 @@ import Layout from '@layouts/Layout.astro';
         <p class="mt-6 text-lg leading-8 text-emerald-100">
           Acompañamiento educativo, atención personalizada y participación activa de toda la comunidad escolar.
         </p>
-        <div class="mt-10 flex items-center justify-center gap-x-6">
+        <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-x-6">
           <a
             href="#orientacion"
-            class="rounded-full bg-white px-6 py-3 text-sm font-semibold text-emerald-900 shadow-sm hover:bg-emerald-50 transition-all"
+            class="w-full sm:w-auto text-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-emerald-900 shadow-sm hover:bg-emerald-50 transition-all whitespace-nowrap"
           >
             Ver Orientación
           </a>
           <a
             href="#comunidad"
-            class="text-sm font-semibold leading-6 text-white flex items-center gap-2"
+            class="text-sm font-semibold leading-6 text-white flex items-center gap-2 whitespace-nowrap"
           >
             Comunidad Educativa <span aria-hidden="true">→</span>
           </a>

--- a/frontend/src/pages/secretaria_virtual.astro
+++ b/frontend/src/pages/secretaria_virtual.astro
@@ -15,7 +15,7 @@ const emailSecretariaHref = `mailto:${contacto.emailsecretaria}`;
       class="absolute inset-0 bg-[url('/images/bg-hero.webp')] bg-cover bg-center opacity-10"
     >
     </div>
-    <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8 relative z-10">
+    <div class="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:py-32 lg:px-8 relative z-10">
       <div class="mx-auto max-w-2xl text-center">
         <div
           class="inline-flex items-center gap-2 rounded-full bg-blue-700/50 px-4 py-2 text-sm font-semibold text-blue-100 ring-1 ring-inset ring-blue-400/30 mb-6"

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2,6 +2,7 @@
 pnpm run devyles/global.css */
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,600&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -122,9 +122,26 @@ body {
         padding: 0.75rem 1rem;
     }
 
+    /* Enlaces de navegación (barra superior y footer): área táctil mínima */
+    [aria-label="Accesos rápidos institucionales"] a,
+    [aria-label="Accesos rápidos institucionales"] button,
+    footer nav a,
+    footer nav button {
+        min-height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
     /* Grid responsive mejorado */
     .grid {
         gap: 0.75rem;
+    }
+
+    /* Desactiva blobs decorativos difuminados en móvil (coste de render) */
+    [class*="blur-3xl"],
+    [class*="blur-2xl"] {
+        display: none !important;
     }
 
     /* Imágenes responsive */


### PR DESCRIPTION
## Resumen

Mantiene el diseño actual de `main` e introduce un **nuevo hero** en la home (la sección de la foto del instituto) con estilo editorial, además de varios refinamientos mobile-first y un fix de overflow en desktop.

## Cambios

### Hero
- Foto del centro a pantalla completa con overlay oscuro uniforme y texto editorial abajo-izquierda (titular en serif Newsreader, botón limpio).
- Hero autónomo: la fuente serif se aplica inline (no depende de variables CSS). Se añade el import de Newsreader a `global.css`.

### Fix desktop
- Los desplegables de los 2 últimos menús (Orientación, Secretaría Virtual) se alinean a la derecha en vez de centrados; antes el panel del último ítem se salía del viewport y generaba **scroll horizontal** en toda la página.

### Refinamientos mobile-first
- Áreas táctiles de la barra superior y del footer a **mín. 44px** (la regla previa solo cubría botones).
- Footer: arreglada la alineación de los enlaces legales y el tamaño de "Contacto".
- Heros internos (secretaría, orientación): menos padding en móvil (`py-16`) para reducir scroll muerto.
- Orientación: CTAs del hero apilados en móvil.
- Rendimiento: blobs decorativos `blur-3xl/2xl` ocultos en móvil.

### Mantenimiento
- `.claude/` añadida al `.gitignore` (config local de herramientas).

## Verificación
- Build verde (`npm run build`).
- Auditoría en móvil (375px) y desktop (1280px): **cero overflow horizontal** en todas las páginas, viewport meta correcto, inputs a 16px (sin zoom iOS), grids responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)